### PR TITLE
Fix #16: Disallow user names with spaces

### DIFF
--- a/api/controllers/auth/Signup.js
+++ b/api/controllers/auth/Signup.js
@@ -77,6 +77,16 @@ async function validateInput(username, email, password, confirmPassword) {
     errors.push("Username in use.");
   }
 
+  // Username regex: only allow lowercase letters, underscores, dashes, and periods
+  const usernameRegex = /^[a-z._-]+$/;
+  // Check if username is valid
+  if (!usernameRegex.test(username)) {
+    error = true;
+    errors.push(
+      "Username can only contain lowercase letters, underscores, dashes, and periods. Spaces are not allowed."
+    );
+  }
+
   // check if email is valid. If valid check if in use
   if (!validateEmail) {
     error = true;


### PR DESCRIPTION
Hello,
Hope you're doing well
As it has been requested in issue #16, I have added a condition to check if the username consists of spaces or not
If it does, then an error would be thrown
Else the flow would go through as it is
Here's an example:

![image](https://github.com/user-attachments/assets/ce838d03-2039-42b9-b294-067c85b1d305)

I hope these code changes meet the requirements
Sincere apologies for my mistakes if you find any

Thanks and Regards,
Mohit Kambli