### PR TITLE
api/auth: Password validation in place (Issue #17)

### DIFF
--- a/api/controllers/auth/Signup.js
+++ b/api/controllers/auth/Signup.js
@@ -105,6 +105,14 @@ async function validateInput(username, email, password, confirmPassword) {
     errors.push("Passwords do not match");
   }
 
+  //validating password
+  if (!validatePassword(password)) {
+    error = true;
+    errors.push(
+      "Password must be at least 12 characters long, with at least one special character and one number."
+    );
+  }
+
   // if error returns errors if not returns null
   if (error) {
     return errors;
@@ -122,4 +130,19 @@ function validateEmail(email) {
     );
 }
 
+//password validation function
+function validatePassword(password) {
+  const hasNumber = /\d/; // checks for at least one digit
+  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/; //checks for at least one special character
+
+  if (password.length < 12) return false;
+  
+  if (!hasNumber.test(password) || !hasSpecialChar.test(password))  return false;
+  
+  return true;
+}
+
+
 export default signup;
+
+

--- a/api/controllers/auth/Signup.js
+++ b/api/controllers/auth/Signup.js
@@ -134,8 +134,7 @@ function validateEmail(email) {
 function validatePassword(password) {
   const hasNumber = /\d/; // checks for at least one digit
   const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/; //checks for at least one special character
-
-  if (password.length < 12) return false;
+  if (!password || password.length < 12) return false;
   
   if (!hasNumber.test(password) || !hasSpecialChar.test(password))  return false;
   


### PR DESCRIPTION
I have implemented the required password validation using regex.
This solves issue #17.

![image](https://github.com/user-attachments/assets/f94ed1fd-779c-4653-ba76-a74bcd43b84d)
![image](https://github.com/user-attachments/assets/405958e1-3a4c-4862-bb82-928c54a7d40d)
